### PR TITLE
Add zIndex prop setting on absolutely positioned element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,8 @@ export default class ResizableAndMovable extends Component {
                width:`${start.width}px`,
                height:`${start.height}px`,
                cursor: "move",
-               position:'absolute'
+               position:'absolute',
+               zIndex: `${zIndex}`
              }}>
           <Resizable
              ref='resizable'


### PR DESCRIPTION
If zIndex prop is set, it needs to be in the style of the same component that's positioned absolutely.  Otherwise the moveable layers won't respect each other's order.