### PR TITLE
Fix situations when on dragStop you wanted to revert to 0,0 position

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,8 +118,8 @@ export default class ResizableAndMovable extends Component {
   }
 
   componentWillReceiveProps({ x, y }) {
-    if (x !== this.props.x) this.setState({ x });
-    if (y !== this.props.y) this.setState({ y });
+    if (x !== this.state.x) this.setState({ x });
+    if (y !== this.state.y) this.setState({ y });
   }
 
   onResizeStart(dir, styleSize, clientSize, e) {


### PR DESCRIPTION
If you init the component with x=0 and y=0 and then want to drag it to some position and revert ondragstop you would fail, because old comparison would do initial props (0,0) compared to new 0,0 passed via nextprops.

// was passing 0,0 on drag stop to component and check went falsy because initial props were also 0,0.
componentWillReceiveProps({ x, y }) {
    if (x !== this.props.x) this.setState({ x });
    if (y !== this.props.y) this.setState({ y });
}

This is useful when dragging component over something and triggering event like in drag and drop. and then want to re-set position.