### PR TITLE
Restrict the direction of moving, not just resizing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,13 @@ export default class ResizableAndMovable extends Component {
 
   onDrag(e, ui) {
     if (this.isResizing) return;
-    this.setState({ x: ui.position.left, y: ui.position.top });
+    const allowX = this.props.moveAxis === 'x';
+    const allowY = this.props.moveAxis === 'y';
+    const allowBoth = this.props.moveAxis === 'both';
+    this.setState({
+      x: allowX || allowBoth ? ui.position.left : this.state.x,
+      y: allowY || allowBoth ? ui.position.top : this.state.y,
+    });
     this.props.onDrag(e, ui);
   }
 


### PR DESCRIPTION
I was somewhat confused when, despite setting the `moveAxis` to `x`, I was still able to move the box in all directions. I then realized that `moveAxis` only restricted _resizing_ and not _moving_.

With these changes, `moveAxis` also restricts _moving_.